### PR TITLE
fix: remove static STATUS labels

### DIFF
--- a/app/components/StatusTerminal.tsx
+++ b/app/components/StatusTerminal.tsx
@@ -88,7 +88,7 @@ export function StatusTerminal() {
     <div className={styles.container}>
       <div className={styles.header}>
         <div className={styles.dot} />
-        <span>TERMINAL // GITHUB_ACTIVITY // STATUS: CONNECTED</span>
+        <span>TERMINAL // GITHUB_ACTIVITY</span>
       </div>
       <div className={styles.logEntries}>
         {loading ? (

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -23,7 +23,6 @@ export default function Index() {
           />
           <div className={styles.statusIndicator}>
             <div className={styles.statusDot} />
-            [ STATUS: ACTIVE ]
           </div>
         </div>
         


### PR DESCRIPTION
Removes hardcoded '[ STATUS: ACTIVE ]' from the hero avatar section and 'STATUS: CONNECTED' from the terminal header.