### PR TITLE
fix: remove green status dot from hero avatar

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -21,9 +21,7 @@ export default function Index() {
             alt="Tirso Navarro" 
             className={styles.avatar} 
           />
-          <div className={styles.statusIndicator}>
-            <div className={styles.statusDot} />
-          </div>
+
         </div>
         
         <div className={styles.identityInfo}>


### PR DESCRIPTION
Removes the green glowing status dot that was under the profile picture in the hero section.