### PR TITLE
feat: update skills page with linked cards and repo links

### DIFF
--- a/app/routes/skills._index.tsx
+++ b/app/routes/skills._index.tsx
@@ -8,23 +8,53 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-const everydaySkills = [
-  "Claude Code",
-  "Gemini CLI",
-  "LangChain",
-  "LangGraph",
-  "ChromaDB",
-  "Ollama",
-  "MCP Servers",
-  "Tavily",
-  "Perplexity API",
-  "OpenAI",
-  "DeepSeek",
-  "SMOL Agents",
-  "n8n",
-  "Shopify Flow",
-  "Docker",
-  "GitHub Actions",
+interface SkillCard {
+  title: string;
+  subtitle: string;
+  repo: string;
+}
+
+const everydaySkills: SkillCard[] = [
+  {
+    title: "Superpowers",
+    subtitle: "Project-specific RAG from your codebase, docs, and git history — built for AI coding agents.",
+    repo: "https://github.com/obra/superpowers",
+  },
+  {
+    title: "Shopify AI Toolkit",
+    subtitle: "Connect AI tools directly to Shopify's platform with skills for docs, API schemas, and code validation.",
+    repo: "https://github.com/Shopify/Shopify-AI-Toolkit",
+  },
+  {
+    title: "Vercel CLI Skills",
+    subtitle: "The open agent skills tool — create, share, and run skills via `npx skills` across 27+ coding agents.",
+    repo: "https://github.com/vercel-labs/skills",
+  },
+  {
+    title: "Supabase CLI Skills",
+    subtitle: "Agent skills for Supabase development — database, auth, Edge Functions, and Postgres best practices.",
+    repo: "https://github.com/supabase/agent-skills",
+  },
+  {
+    title: "Google Workspace CLI Skills",
+    subtitle: "One CLI for all of Google Workspace — Drive, Gmail, Calendar, Sheets, Docs, Chat, Admin. 100+ agent skills.",
+    repo: "https://github.com/googleworkspace/cli",
+  },
+  {
+    title: "Tavily Search Skills",
+    subtitle: "Web search, content extraction, crawling, and deep research via the Tavily CLI — optimized for AI agents.",
+    repo: "https://github.com/tavily-ai/skills",
+  },
+  {
+    title: "Anthropic Skills",
+    subtitle: "Anthropic's official skills library — the canonical repository of agent skills for Claude and beyond.",
+    repo: "https://github.com/anthropics/skills",
+  },
+  {
+    title: "Graphify Skills",
+    subtitle: "Transform any project into a queryable knowledge graph — maps code, docs, PDFs, images, and videos.",
+    repo: "https://github.com/safishamsi/graphify",
+  },
 ];
 
 export default function SkillsIndex() {
@@ -39,7 +69,7 @@ export default function SkillsIndex() {
           tested, and integrated into real-world systems.
         </p>
         <a
-          href="https://github.com/tn-py"
+          href="https://github.com/stars/tn-py/lists/skills"
           target="_blank"
           rel="noopener noreferrer"
           className={styles.cta}
@@ -56,9 +86,17 @@ export default function SkillsIndex() {
         </div>
         <div className={styles.skillGrid}>
           {everydaySkills.map((skill) => (
-            <span key={skill} className={styles.skillBadge}>
-              {skill}
-            </span>
+            <a
+              key={skill.title}
+              href={skill.repo}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.skillCard}
+            >
+              <h3 className={styles.cardTitle}>{skill.title}</h3>
+              <p className={styles.cardSubtitle}>{skill.subtitle}</p>
+              <span className={styles.cardLink}>View on GitHub &rarr;</span>
+            </a>
           ))}
         </div>
       </section>

--- a/app/styles/Skills.module.css
+++ b/app/styles/Skills.module.css
@@ -104,29 +104,56 @@
 /* ─── SKILL GRID ─── */
 
 .skillGrid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
 }
 
-.skillBadge {
+.skillCard {
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  padding: 0.6rem 1rem;
-  border-radius: 6px;
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  transition: all 0.2s ease;
-  cursor: default;
+  border-radius: 8px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-decoration: none;
+  transition: all 0.25s ease;
 }
 
-.skillBadge:hover {
-  color: var(--text-primary);
+.skillCard:hover {
   border-color: var(--accent-blue);
-  background: rgba(88, 166, 255, 0.08);
-  box-shadow: 0 0 12px rgba(88, 166, 255, 0.1);
-  transform: translateY(-1px);
+  background: rgba(88, 166, 255, 0.05);
+  box-shadow: 0 0 20px rgba(88, 166, 255, 0.1);
+  transform: translateY(-2px);
+}
+
+.cardTitle {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.cardSubtitle {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  margin: 0;
+  flex: 1;
+}
+
+.cardLink {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent-blue);
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+}
+
+.skillCard:hover .cardLink {
+  opacity: 1;
 }
 
 /* ─── PLACEHOLDER CARDS ─── */


### PR DESCRIPTION
Replaced flat badge list with skill cards featuring titles, descriptions, and GitHub repo links. Updated CTA to point to GitHub skills list.